### PR TITLE
Changed the internal _RenderBar function to stock, to prevent a "symb…

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -241,7 +241,7 @@ stock HidePlayerProgressBar(playerid, PlayerBar:barid)
 ==============================================================================*/
 
 
-_RenderBar(playerid, barid)
+stock _RenderBar(playerid, barid)
 {
 	if(!IsPlayerConnected(playerid))
 		return false;


### PR DESCRIPTION
…ol is never used" message, when you do not use any progress bar functions in your script.
