### PR TITLE
Corrections to pawn.json

### DIFF
--- a/pawn.json
+++ b/pawn.json
@@ -6,8 +6,7 @@
     "dependencies": [
         "Southclaws/samp-stdlib",
         "Southclaws/samp-logger",
-        "Zeex/amx_assembly",
-        "Misiur/YSI-Includes"
+        "pawn-lang/YSI-Includes"
     ],
     "dev_dependencies": [
         "Southclaws/ut_mock_players"


### PR DESCRIPTION
Used the correct YSI repo, amx_assembly doesn't need to be a dependency at all