### PR TITLE
Fixed tag mismatch

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -16,7 +16,7 @@
 #include <YSI_Coding\y_hooks>
 
 
-#define MAX_PLAYER_BARS (MAX_PLAYER_TEXT_DRAWS / 3)
+#define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
 #define INVALID_PLAYER_BAR_VALUE (Float:0xFFFFFFFF)
 #define INVALID_PLAYER_BAR_ID (PlayerBar:-1)
 


### PR DESCRIPTION
So, problem was in samp-stdlib:

#if !defined MAX_PLAYER_TEXT_DRAWS
	#define MAX_PLAYER_TEXT_DRAWS              (PlayerText:256)
#endif

It adds PlayerText tag (PlayerText:256) to MAX_PLAYER_TEXT_DRAWS.