### PR TITLE
Refactoring part 3: normalising codestyles moments

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -52,7 +52,8 @@ new
 	if(defined _INC_y_iterate)
 		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 	#endif
-    pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
+	pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA]
+;
 
 //	Returns free player progress bar.
 stock PlayerBar:PlayerBarUI_FindFree(const playerid) {

--- a/progress2.inc
+++ b/progress2.inc
@@ -66,14 +66,23 @@ stock PlayerBar:PlayerBarUI_FindFree(const playerid) {
 }
 
 forward PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,
-	colour = 0xFF1C1CFF, Float:max=100.0, direction=BAR_DIRECTION_RIGHT);
+	playerid,
+	Float:x, Float:y,
+	Float:width=55.5, Float:height=3.2,
+	colour = 0xFF1C1CFF,
+	Float:max=100.0,
+	direction=BAR_DIRECTION_RIGHT
+);
 forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
 forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
 
 stock PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width = 55.5, Float:height = 3.2,
-	colour = 0xFF1C1CFF, Float:max = 100.0, direction = BAR_DIRECTION_RIGHT
+	playerid,
+	Float:x, Float:y,
+	Float:width = 55.5, Float:height = 3.2,
+	colour = 0xFF1C1CFF,
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
 ) {
 	if(!IsPlayerConnected(playerid)) {
 		#if(defined _logger_included)

--- a/progress2.inc
+++ b/progress2.inc
@@ -49,7 +49,7 @@ enum E_BAR_TEXT_DRAW {
 static pbar_TextDraw[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_TEXT_DRAW];
 
 new
-	if(defined _INC_y_iterate)
+	#if(defined _INC_y_iterate)
 		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 	#endif
 	pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA]
@@ -497,6 +497,7 @@ hook OnScriptExit() {
 		}
 	}
 }
+#endif
 
 stock DestroyAllPlayerProgressBars(playerid) {
 	for(new i = 0; i < MAX_PLAYER_BARS; i++) {
@@ -505,7 +506,6 @@ stock DestroyAllPlayerProgressBars(playerid) {
 
 	return 1;
 }
-#endif
 
 stock Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction) {
 	new Float:result;

--- a/progress2.inc
+++ b/progress2.inc
@@ -68,10 +68,10 @@ stock PlayerBar:PlayerBarUI_FindFree(const playerid) {
 forward PlayerBar:CreatePlayerProgressBar(
 	playerid,
 	Float:x, Float:y,
-	Float:width=55.5, Float:height=3.2,
+	Float:width = 55.5, Float:height = 3.2,
 	colour = 0xFF1C1CFF,
-	Float:max=100.0,
-	direction=BAR_DIRECTION_RIGHT
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
 );
 forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
 forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
@@ -84,7 +84,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	Float:max = 100.0,
 	direction = BAR_DIRECTION_RIGHT
 ) {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		#if(defined _logger_included)
 		Logger_Err("attempt to create player progress bar for invalid player",
 			Logger_I("playerid", playerid));
@@ -93,7 +93,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	}
 	#if(defined _INC_y_iterate)
 	new barid = Iter_Free(pbar_Index[playerid]);
-	if(barid == ITER_NONE) {
+	if( barid == ITER_NONE ) {
 		#if(defined _logger_included)
 		Logger_Err("MAX_PLAYER_BARS limit reached.");
 		#endif
@@ -133,7 +133,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 }
 
 stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -149,10 +149,10 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -166,7 +166,7 @@ stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 }
 
 stock HidePlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -193,7 +193,7 @@ stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
 // pbar_posX
 // pbar_posY
 stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -204,7 +204,7 @@ stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
 }
 
 stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return false;
 	}
 
@@ -218,7 +218,7 @@ stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
 
 // pbar_width
 stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -226,7 +226,7 @@ stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -239,7 +239,7 @@ stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
 
 // pbar_height
 stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -247,7 +247,7 @@ stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -260,7 +260,7 @@ stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
 
 // pbar_colour
 stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -268,7 +268,7 @@ stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -283,7 +283,7 @@ stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
 
 // pbar_maxValue
 stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -291,7 +291,7 @@ stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -303,14 +303,14 @@ stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
 
 // pbar_progressValue
 stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
-	if(value < 0.0) {
+	if( value < 0.0 ) {
 		value = 0.0;
 	} else {
-		if(value > pbar_Data[playerid][_:barid][pbar_maxValue]) {
+		if( value > pbar_Data[playerid][_:barid][pbar_maxValue] ) {
 			value = pbar_Data[playerid][_:barid][pbar_maxValue];
 		}
 	}
@@ -340,7 +340,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 		}
 	}
 
-	if(pbar_Data[playerid][_:barid][pbar_show]) {
+	if( pbar_Data[playerid][_:barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, barid);
 	}
 
@@ -348,7 +348,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 }
 
 stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -357,7 +357,7 @@ stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
 
 // pbar_direction
 stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -365,7 +365,7 @@ stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -381,11 +381,11 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 
 _progress2_renderBar(playerid, barid)
 {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}
 
-	if(!IsValidPlayerProgressBar(playerid, PlayerBar:barid)) {
+	if( !IsValidPlayerProgressBar(playerid, PlayerBar:barid) ) {
 		return false;
 	}
 
@@ -472,7 +472,7 @@ _progress2_renderBar(playerid, barid)
 		}
 	}
 
-	if(pbar_Data[playerid][barid][pbar_show]) {
+	if( pbar_Data[playerid][barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, PlayerBar:barid);
 	}
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -13,7 +13,7 @@
 #tryinclude <logger>
 #tryinclude <YSI_Data\y_iterate>
 
-#include <YSI_Coding\y_hooks>
+#tryinclude <YSI_Coding\y_hooks>
 
 
 #define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
@@ -469,6 +469,7 @@ _progress2_renderBar(playerid, barid)
 	return true;
 }
 
+#if(defined __INC_y_hooks)
 hook OnScriptInit() {
 	#if(defined _INC_y_iterate)
 	Iter_Init(pbar_Index);
@@ -495,6 +496,7 @@ stock DestroyAllPlayerProgressBars(playerid) {
 
 	return 1;
 }
+#endif
 
 stock Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction) {
 	new Float:result;

--- a/progress2.inc
+++ b/progress2.inc
@@ -113,7 +113,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-   return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 	if(!IsValidPlayerProgressBar(playerid, barid)) {

--- a/progress2.inc
+++ b/progress2.inc
@@ -10,7 +10,7 @@
 #define _progress2_included
 
 #include <a_samp>
-#include <logger>
+#tryinclude <logger>
 #include <YSI_Data\y_iterate>
 
 #include <YSI_Coding\y_hooks>
@@ -61,15 +61,19 @@ stock PlayerBar:CreatePlayerProgressBar(
 	colour = 0xFF1C1CFF, Float:max = 100.0, direction = BAR_DIRECTION_RIGHT
 ) {
 	if(!IsPlayerConnected(playerid)) {
+		#if(defined _logger_included)
 		Logger_Err("attempt to create player progress bar for invalid player",
 			Logger_I("playerid", playerid));
+		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
 
 	new barid = Iter_Free(pbar_Index[playerid]);
 
 	if(barid == ITER_NONE) {
+		#if(defined _logger_included)
 		Logger_Err("MAX_PLAYER_BARS limit reached.");
+		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -147,8 +147,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	return 1;
 }
 
-stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
-{
+stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid) {
 	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
@@ -379,8 +378,7 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 	Internal
 */
 
-_progress2_renderBar(playerid, barid)
-{
+_progress2_renderBar(playerid, barid) {
 	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}

--- a/progress2.inc
+++ b/progress2.inc
@@ -28,6 +28,7 @@ enum {
 }
 
 enum E_BAR_DATA {
+	bool:is_created,
 	bool:pbar_show,
 	Float:pbar_posX,
 	Float:pbar_posY,
@@ -52,6 +53,16 @@ new
 		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 	#endif
     pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
+
+//	Returns free player progress bar.
+stock PlayerBar:PlayerBarUI_FindFree(const playerid) {
+	for(new PlayerBar:barid = PlayerBar:0; barid < MAX_PLAYER_BARS; ++barid) {
+		if( !pbar_Data[playerid][barid][is_created] ) {
+			return barid;
+		}
+	}
+	return INVALID_PLAYER_BAR_ID;
+}
 
 forward PlayerBar:CreatePlayerProgressBar(
 	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,
@@ -79,13 +90,20 @@ stock PlayerBar:CreatePlayerProgressBar(
 		return INVALID_PLAYER_BAR_ID;
 	}
 	#else
-	// TODO: make iter-less analog (see next commit).
+	new barid = PlayerBarUI_FindFree(playerid);
+	if( barid == INVALID_PLAYER_BAR_ID ) {
+		#if(defined _logger_included)
+		Logger_Err("MAX_PLAYER_BARS limit reached.");
+		#endif
+		return INVALID_PLAYER_BAR_ID;
+	}
 	#endif
 
 
 	pbar_TextDraw[playerid][barid][pbar_back] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_fill] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_main] = PlayerText:INVALID_TEXT_DRAW;
+	pbar_Data[playerid][barid][is_created] = true;
 	pbar_Data[playerid][barid][pbar_show] = false;
 	pbar_Data[playerid][barid][pbar_posX] = x;
 	pbar_Data[playerid][barid][pbar_posY] = y;
@@ -112,6 +130,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_back]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_fill]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_main]);
+	pbar_Data[playerid][barid][is_created] = false;
 	#if(defined _INC_y_iterate)
 	Iter_Remove(pbar_Index[playerid], _:barid);
 	#endif
@@ -155,8 +174,7 @@ stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
 		return Iter_Contains(pbar_Index[playerid], _:barid);
 	#else
 		if( INVALID_PLAYER_BAR_ID < barid && barid < MAX_PLAYER_BARS ) {
-			// TODO: add is_created flag in pbar_Data
-			// return pbar_Data[playerid][barid][is_created];
+			return pbar_Data[playerid][barid][is_created];
 		}
 		return false;
 	#endif

--- a/progress2.inc
+++ b/progress2.inc
@@ -16,9 +16,9 @@
 #include <YSI_Coding\y_hooks>
 
 
-#define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
-#define INVALID_PLAYER_BAR_VALUE (Float:0xFFFFFFFF)
-#define INVALID_PLAYER_BAR_ID (PlayerBar:-1)
+#define MAX_PLAYER_BARS					(_:MAX_PLAYER_TEXT_DRAWS / 3)
+#define INVALID_PLAYER_BAR_VALUE		(Float:0xFFFFFFFF)
+#define INVALID_PLAYER_BAR_ID			(PlayerBar:-1)
 
 enum {
 	BAR_DIRECTION_RIGHT,

--- a/progress2.inc
+++ b/progress2.inc
@@ -11,7 +11,7 @@
 
 #include <a_samp>
 #tryinclude <logger>
-#include <YSI_Data\y_iterate>
+#tryinclude <YSI_Data\y_iterate>
 
 #include <YSI_Coding\y_hooks>
 
@@ -47,7 +47,10 @@ enum E_BAR_TEXT_DRAW {
 
 static pbar_TextDraw[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_TEXT_DRAW];
 
-new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
+new
+	if(defined _INC_y_iterate)
+		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
+	#endif
     pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
 
 forward PlayerBar:CreatePlayerProgressBar(
@@ -67,15 +70,18 @@ stock PlayerBar:CreatePlayerProgressBar(
 		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
-
+	#if(defined _INC_y_iterate)
 	new barid = Iter_Free(pbar_Index[playerid]);
-
 	if(barid == ITER_NONE) {
 		#if(defined _logger_included)
 		Logger_Err("MAX_PLAYER_BARS limit reached.");
 		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
+	#else
+	// TODO: make iter-less analog (see next commit).
+	#endif
+
 
 	pbar_TextDraw[playerid][barid][pbar_back] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_fill] = PlayerText:INVALID_TEXT_DRAW;
@@ -90,8 +96,9 @@ stock PlayerBar:CreatePlayerProgressBar(
 	pbar_Data[playerid][barid][pbar_progressValue] = 0.0;
 	pbar_Data[playerid][barid][pbar_direction] = direction;
 
+	#if(defined _INC_y_iterate)
 	Iter_Add(pbar_Index[playerid], barid);
-
+	#endif
 	_progress2_renderBar(playerid, barid);
 
 	return PlayerBar:barid;
@@ -105,9 +112,9 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_back]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_fill]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_main]);
-
+	#if(defined _INC_y_iterate)
 	Iter_Remove(pbar_Index[playerid], _:barid);
-
+	#endif
 	return 1;
 }
 
@@ -144,7 +151,15 @@ stock HidePlayerProgressBar(playerid, PlayerBar:barid) {
 }
 
 stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
-	return Iter_Contains(pbar_Index[playerid], _:barid);
+	#if(defined _INC_y_iterate)
+		return Iter_Contains(pbar_Index[playerid], _:barid);
+	#else
+		if( INVALID_PLAYER_BAR_ID < barid && barid < MAX_PLAYER_BARS ) {
+			// TODO: add is_created flag in pbar_Data
+			// return pbar_Data[playerid][barid][is_created];
+		}
+		return false;
+	#endif
 }
 
 // pbar_posX
@@ -437,11 +452,15 @@ _progress2_renderBar(playerid, barid)
 }
 
 hook OnScriptInit() {
+	#if(defined _INC_y_iterate)
 	Iter_Init(pbar_Index);
+	#endif
 }
 
 hook OnPlayerDisconnect(playerid, reason) {
+	#if(defined _INC_y_iterate)
 	Iter_Clear(pbar_Index[playerid]);
+	#endif
 }
 
 hook OnScriptExit() {

--- a/progress2.inc
+++ b/progress2.inc
@@ -51,14 +51,23 @@ new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
     pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
 
 forward PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,
-	colour = 0xFF1C1CFF, Float:max=100.0, direction=BAR_DIRECTION_RIGHT);
+	playerid,
+	Float:x, Float:y,
+	Float:width=55.5, Float:height=3.2,
+	colour = 0xFF1C1CFF,
+	Float:max=100.0,
+	direction=BAR_DIRECTION_RIGHT
+);
 forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
 forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
 
 stock PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width = 55.5, Float:height = 3.2,
-	colour = 0xFF1C1CFF, Float:max = 100.0, direction = BAR_DIRECTION_RIGHT
+	playerid,
+	Float:x, Float:y,
+	Float:width = 55.5, Float:height = 3.2,
+	colour = 0xFF1C1CFF,
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
 ) {
 	if(!IsPlayerConnected(playerid)) {
 		#if(defined _logger_included)

--- a/progress2.inc
+++ b/progress2.inc
@@ -53,10 +53,10 @@ new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 forward PlayerBar:CreatePlayerProgressBar(
 	playerid,
 	Float:x, Float:y,
-	Float:width=55.5, Float:height=3.2,
+	Float:width = 55.5, Float:height = 3.2,
 	colour = 0xFF1C1CFF,
-	Float:max=100.0,
-	direction=BAR_DIRECTION_RIGHT
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
 );
 forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
 forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
@@ -69,7 +69,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	Float:max = 100.0,
 	direction = BAR_DIRECTION_RIGHT
 ) {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		#if(defined _logger_included)
 		Logger_Err("attempt to create player progress bar for invalid player",
 			Logger_I("playerid", playerid));
@@ -78,8 +78,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	}
 
 	new barid = Iter_Free(pbar_Index[playerid]);
-
-	if(barid == ITER_NONE) {
+	if( barid == ITER_NONE ) {
 		#if(defined _logger_included)
 		Logger_Err("MAX_PLAYER_BARS limit reached.");
 		#endif
@@ -107,7 +106,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 }
 
 stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -122,10 +121,10 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -139,7 +138,7 @@ stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 }
 
 stock HidePlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -159,7 +158,7 @@ stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
 // pbar_posX
 // pbar_posY
 stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -170,7 +169,7 @@ stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
 }
 
 stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return false;
 	}
 
@@ -184,7 +183,7 @@ stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
 
 // pbar_width
 stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -192,7 +191,7 @@ stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -205,7 +204,7 @@ stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
 
 // pbar_height
 stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -213,7 +212,7 @@ stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -226,7 +225,7 @@ stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
 
 // pbar_colour
 stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -234,7 +233,7 @@ stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -249,7 +248,7 @@ stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
 
 // pbar_maxValue
 stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -257,7 +256,7 @@ stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -269,14 +268,14 @@ stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
 
 // pbar_progressValue
 stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
-	if(value < 0.0) {
+	if( value < 0.0 ) {
 		value = 0.0;
 	} else {
-		if(value > pbar_Data[playerid][_:barid][pbar_maxValue]) {
+		if( value > pbar_Data[playerid][_:barid][pbar_maxValue] ) {
 			value = pbar_Data[playerid][_:barid][pbar_maxValue];
 		}
 	}
@@ -306,7 +305,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 		}
 	}
 
-	if(pbar_Data[playerid][_:barid][pbar_show]) {
+	if( pbar_Data[playerid][_:barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, barid);
 	}
 
@@ -314,7 +313,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 }
 
 stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -323,7 +322,7 @@ stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
 
 // pbar_direction
 stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -331,7 +330,7 @@ stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -347,11 +346,11 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 
 _progress2_renderBar(playerid, barid)
 {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}
 
-	if(!IsValidPlayerProgressBar(playerid, PlayerBar:barid)) {
+	if( !IsValidPlayerProgressBar(playerid, PlayerBar:barid) ) {
 		return false;
 	}
 
@@ -438,7 +437,7 @@ _progress2_renderBar(playerid, barid)
 		}
 	}
 
-	if(pbar_Data[playerid][barid][pbar_show]) {
+	if( pbar_Data[playerid][barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, PlayerBar:barid);
 	}
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -119,8 +119,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	return 1;
 }
 
-stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
-{
+stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid) {
 	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
@@ -344,8 +343,7 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 	Internal
 */
 
-_progress2_renderBar(playerid, barid)
-{
+_progress2_renderBar(playerid, barid) {
 	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}

--- a/progress2.inc
+++ b/progress2.inc
@@ -452,8 +452,9 @@ hook OnPlayerDisconnect(playerid, reason) {
 
 hook OnScriptExit() {
 	for(new i = 0; i < MAX_PLAYERS; i++) {
-		if(IsPlayerConnected(i))
+		if( IsPlayerConnected(i) ) {
 			DestroyAllPlayerProgressBars(i);
+		}
 	}
 }
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -492,8 +492,9 @@ hook OnPlayerDisconnect(playerid, reason) {
 
 hook OnScriptExit() {
 	for(new i = 0; i < MAX_PLAYERS; i++) {
-		if(IsPlayerConnected(i))
+		if( IsPlayerConnected(i) ) {
 			DestroyAllPlayerProgressBars(i);
+		}
 	}
 }
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -16,9 +16,9 @@
 #tryinclude <YSI_Coding\y_hooks>
 
 
-#define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
-#define INVALID_PLAYER_BAR_VALUE (Float:0xFFFFFFFF)
-#define INVALID_PLAYER_BAR_ID (PlayerBar:-1)
+#define MAX_PLAYER_BARS					(_:MAX_PLAYER_TEXT_DRAWS / 3)
+#define INVALID_PLAYER_BAR_VALUE		(Float:0xFFFFFFFF)
+#define INVALID_PLAYER_BAR_ID			(PlayerBar:-1)
 
 enum {
 	BAR_DIRECTION_RIGHT,

--- a/progress2.inc
+++ b/progress2.inc
@@ -140,7 +140,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-   return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 	if(!IsValidPlayerProgressBar(playerid, barid)) {


### PR DESCRIPTION
Apply able after "Refactoring part 2"

Aligned columns of definitons with tabs - now looks like table.

Fixed issues with codestyle at allocation memory, multiple spaces as tabs, missed spaces.
[Fixed space series to tabulation.]
Rewritten definition of functions with many arguments to many lines by groups.
Normalised {}-braces use under K&R style as everywhere else in exist …
