### PR TITLE
Refactoring part 2: optional Y-lib.

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -11,7 +11,7 @@
 
 #include <a_samp>
 #tryinclude <logger>
-#include <YSI_Data\y_iterate>
+#tryinclude <YSI_Data\y_iterate>
 
 #include <YSI_Coding\y_hooks>
 
@@ -47,7 +47,10 @@ enum E_BAR_TEXT_DRAW {
 
 static pbar_TextDraw[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_TEXT_DRAW];
 
-new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
+new
+	#if(defined _INC_y_iterate)
+		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
+	#endif
     pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
 
 forward PlayerBar:CreatePlayerProgressBar(
@@ -67,7 +70,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
-
+	#if(defined _INC_y_iterate)
 	new barid = Iter_Free(pbar_Index[playerid]);
 
 	if(barid == ITER_NONE) {
@@ -76,6 +79,9 @@ stock PlayerBar:CreatePlayerProgressBar(
 		#endif
 		return INVALID_PLAYER_BAR_ID;
 	}
+	#else
+	// TODO: make iter-less analog (see next commit).
+	#endif
 
 	pbar_TextDraw[playerid][barid][pbar_back] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_fill] = PlayerText:INVALID_TEXT_DRAW;
@@ -90,7 +96,9 @@ stock PlayerBar:CreatePlayerProgressBar(
 	pbar_Data[playerid][barid][pbar_progressValue] = 0.0;
 	pbar_Data[playerid][barid][pbar_direction] = direction;
 
+	#if(defined _INC_y_iterate)
 	Iter_Add(pbar_Index[playerid], barid);
+	#endif
 
 	_progress2_renderBar(playerid, barid);
 
@@ -105,8 +113,9 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_back]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_fill]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_main]);
-
+	#if(defined _INC_y_iterate)
 	Iter_Remove(pbar_Index[playerid], _:barid);
+	#endif
 
 	return 1;
 }
@@ -144,7 +153,15 @@ stock HidePlayerProgressBar(playerid, PlayerBar:barid) {
 }
 
 stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
-	return Iter_Contains(pbar_Index[playerid], _:barid);
+	#if(defined _INC_y_iterate)
+		return Iter_Contains(pbar_Index[playerid], _:barid);
+	#else
+		if( INVALID_PLAYER_BAR_ID < barid && barid < MAX_PLAYER_BARS ) {
+			// TODO: add is_created flag in pbar_Data
+			// return pbar_Data[playerid][barid][is_created];
+		}
+		return false;
+	#endif
 }
 
 // pbar_posX
@@ -437,11 +454,15 @@ _progress2_renderBar(playerid, barid)
 }
 
 hook OnScriptInit() {
+	#if(defined _INC_y_iterate)
 	Iter_Init(pbar_Index);
+	#endif
 }
 
 hook OnPlayerDisconnect(playerid, reason) {
+	#if(defined _INC_y_iterate)
 	Iter_Clear(pbar_Index[playerid]);
+	#endif
 }
 
 hook OnScriptExit() {

--- a/progress2.inc
+++ b/progress2.inc
@@ -13,7 +13,7 @@
 #tryinclude <logger>
 #tryinclude <YSI_Data\y_iterate>
 
-#include <YSI_Coding\y_hooks>
+#tryinclude <YSI_Coding\y_hooks>
 
 
 #define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
@@ -470,7 +470,7 @@ _progress2_renderBar(playerid, barid)
 
 	return true;
 }
-
+#if(defined __INC_y_hooks)
 hook OnScriptInit() {
 	#if(defined _INC_y_iterate)
 	Iter_Init(pbar_Index);
@@ -489,6 +489,7 @@ hook OnScriptExit() {
 			DestroyAllPlayerProgressBars(i);
 	}
 }
+#endif
 
 stock DestroyAllPlayerProgressBars(playerid) {
 	for(new i = 0; i < MAX_PLAYER_BARS; i++) {

--- a/progress2.inc
+++ b/progress2.inc
@@ -28,6 +28,7 @@ enum {
 }
 
 enum E_BAR_DATA {
+	bool:is_created,
 	bool:pbar_show,
 	Float:pbar_posX,
 	Float:pbar_posY,
@@ -52,6 +53,16 @@ new
 		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 	#endif
     pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
+
+//	Returns free player progress bar.
+stock PlayerBar:PlayerBarUI_FindFree(const playerid) {
+	for(new PlayerBar:barid = PlayerBar:0; barid < MAX_PLAYER_BARS; ++barid) {
+		if( !pbar_Data[playerid][barid][is_created] ) {
+			return barid;
+		}
+	}
+	return INVALID_PLAYER_BAR_ID;
+}
 
 forward PlayerBar:CreatePlayerProgressBar(
 	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,
@@ -80,12 +91,19 @@ stock PlayerBar:CreatePlayerProgressBar(
 		return INVALID_PLAYER_BAR_ID;
 	}
 	#else
-	// TODO: make iter-less analog (see next commit).
+	new barid = PlayerBarUI_FindFree(playerid);
+	if( barid == INVALID_PLAYER_BAR_ID ) {
+		#if(defined _logger_included)
+		Logger_Err("MAX_PLAYER_BARS limit reached.");
+		#endif
+		return INVALID_PLAYER_BAR_ID;
+	}
 	#endif
 
 	pbar_TextDraw[playerid][barid][pbar_back] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_fill] = PlayerText:INVALID_TEXT_DRAW;
 	pbar_TextDraw[playerid][barid][pbar_main] = PlayerText:INVALID_TEXT_DRAW;
+	pbar_Data[playerid][barid][is_created] = true;
 	pbar_Data[playerid][barid][pbar_show] = false;
 	pbar_Data[playerid][barid][pbar_posX] = x;
 	pbar_Data[playerid][barid][pbar_posY] = y;
@@ -113,6 +131,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_back]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_fill]);
 	PlayerTextDrawDestroy(playerid, pbar_TextDraw[playerid][_:barid][pbar_main]);
+	pbar_Data[playerid][barid][is_created] = false;
 	#if(defined _INC_y_iterate)
 	Iter_Remove(pbar_Index[playerid], _:barid);
 	#endif
@@ -157,8 +176,7 @@ stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
 		return Iter_Contains(pbar_Index[playerid], _:barid);
 	#else
 		if( INVALID_PLAYER_BAR_ID < barid && barid < MAX_PLAYER_BARS ) {
-			// TODO: add is_created flag in pbar_Data
-			// return pbar_Data[playerid][barid][is_created];
+			return pbar_Data[playerid][barid][is_created];
 		}
 		return false;
 	#endif


### PR DESCRIPTION
Apply able only after "Refactoring part 1".

Libraries with hooks & iterators are now optional.
Also added property is_created for progress bar due optional use of iterators.

...
I often noticed that ordinary users use either ready-made developments without changes or fixed old versions from dubious sources outside github (in the case when users are not experienced enough and cannot install the necessary libraries themselves).
You can still test the old way. But, if you want to leave these libraries mandatory, then in the future it is worth adding support for dependencies, for example, using github or sampctl.

P.s.: rebase / cherry-pick are nonsense to published data.