### PR TITLE
Refactoring part 3: normalising codestyles moments

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -386,11 +386,10 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 */
 
 _progress2_renderBar(playerid, barid) {
-	if( !IsPlayerConnected(playerid) ) {
-		return false;
-	}
-
-	if( !IsValidPlayerProgressBar(playerid, PlayerBar:barid) ) {
+	if(
+		!IsPlayerConnected(playerid) ||
+		!IsValidPlayerProgressBar(playerid, barid)
+	) {
 		return false;
 	}
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -52,14 +52,21 @@ new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 ;
 
 forward PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,
-	colour = 0xFF1C1CFF, Float:max=100.0, direction=BAR_DIRECTION_RIGHT);
-forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
-forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
+	playerid,
+	Float:x, Float:y,
+	Float:width = 55.5, Float:height = 3.2,
+	colour = 0xFF1C1CFF,
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
+);
 
 stock PlayerBar:CreatePlayerProgressBar(
-	playerid, Float:x, Float:y, Float:width = 55.5, Float:height = 3.2,
-	colour = 0xFF1C1CFF, Float:max = 100.0, direction = BAR_DIRECTION_RIGHT
+	playerid,
+	Float:x, Float:y,
+	Float:width = 55.5, Float:height = 3.2,
+	colour = 0xFF1C1CFF,
+	Float:max = 100.0,
+	direction = BAR_DIRECTION_RIGHT
 ) {
 	if(!IsPlayerConnected(playerid)) {
 		#if(defined _logger_included)

--- a/progress2.inc
+++ b/progress2.inc
@@ -68,7 +68,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	Float:max = 100.0,
 	direction = BAR_DIRECTION_RIGHT
 ) {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		#if(defined _logger_included)
 		Logger_Err("attempt to create player progress bar for invalid player",
 			Logger_I("playerid", playerid));
@@ -78,7 +78,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 
 	new barid = Iter_Free(pbar_Index[playerid]);
 
-	if(barid == ITER_NONE) {
+	if( barid == ITER_NONE ) {
 		#if(defined _logger_included)
 		Logger_Err("MAX_PLAYER_BARS limit reached.");
 		#endif
@@ -106,7 +106,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 }
 
 stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -121,10 +121,10 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -138,7 +138,7 @@ stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 }
 
 stock HidePlayerProgressBar(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -158,7 +158,7 @@ stock IsValidPlayerProgressBar(playerid, PlayerBar:barid) {
 // pbar_posX
 // pbar_posY
 stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -169,7 +169,7 @@ stock GetPlayerProgressBarPos(playerid, PlayerBar:barid, &Float:x, &Float:y) {
 }
 
 stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return false;
 	}
 
@@ -183,7 +183,7 @@ stock SetPlayerProgressBarPos(playerid, PlayerBar:barid, Float:x, Float:y) {
 
 // pbar_width
 stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -191,7 +191,7 @@ stock Float:GetPlayerProgressBarWidth(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -204,7 +204,7 @@ stock SetPlayerProgressBarWidth(playerid, PlayerBar:barid, Float:width) {
 
 // pbar_height
 stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -212,7 +212,7 @@ stock Float:GetPlayerProgressBarHeight(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -225,7 +225,7 @@ stock SetPlayerProgressBarHeight(playerid, PlayerBar:barid, Float:height) {
 
 // pbar_colour
 stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -233,7 +233,7 @@ stock GetPlayerProgressBarColour(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -248,7 +248,7 @@ stock SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour) {
 
 // pbar_maxValue
 stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -256,7 +256,7 @@ stock Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -268,14 +268,14 @@ stock SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max) {
 
 // pbar_progressValue
 stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
-	if(value < 0.0) {
+	if( value < 0.0 ) {
 		value = 0.0;
 	} else {
-		if(value > pbar_Data[playerid][_:barid][pbar_maxValue]) {
+		if( value > pbar_Data[playerid][_:barid][pbar_maxValue] ) {
 			value = pbar_Data[playerid][_:barid][pbar_maxValue];
 		}
 	}
@@ -305,7 +305,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 		}
 	}
 
-	if(pbar_Data[playerid][_:barid][pbar_show]) {
+	if( pbar_Data[playerid][_:barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, barid);
 	}
 
@@ -313,7 +313,7 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 }
 
 stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
 	}
 
@@ -322,7 +322,7 @@ stock Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid) {
 
 // pbar_direction
 stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -330,7 +330,7 @@ stock GetPlayerProgressBarDirection(playerid, PlayerBar:barid) {
 }
 
 stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
-	if(!IsValidPlayerProgressBar(playerid, barid)) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
 
@@ -346,11 +346,11 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 
 _progress2_renderBar(playerid, barid)
 {
-	if(!IsPlayerConnected(playerid)) {
+	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}
 
-	if(!IsValidPlayerProgressBar(playerid, PlayerBar:barid)) {
+	if( !IsValidPlayerProgressBar(playerid, PlayerBar:barid) ) {
 		return false;
 	}
 
@@ -437,7 +437,7 @@ _progress2_renderBar(playerid, barid)
 		}
 	}
 
-	if(pbar_Data[playerid][barid][pbar_show]) {
+	if( pbar_Data[playerid][barid][pbar_show] ) {
 		ShowPlayerProgressBar(playerid, PlayerBar:barid);
 	}
 
@@ -454,7 +454,7 @@ hook OnPlayerDisconnect(playerid, reason) {
 
 hook OnScriptExit() {
 	for(new i = 0; i < MAX_PLAYERS; i++) {
-		if(IsPlayerConnected(i))
+		if( IsPlayerConnected(i) )
 			DestroyAllPlayerProgressBars(i);
 	}
 }

--- a/progress2.inc
+++ b/progress2.inc
@@ -48,7 +48,8 @@ enum E_BAR_TEXT_DRAW {
 static pbar_TextDraw[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_TEXT_DRAW];
 
 new Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
-    pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA];
+	pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA]
+;
 
 forward PlayerBar:CreatePlayerProgressBar(
 	playerid, Float:x, Float:y, Float:width=55.5, Float:height=3.2,

--- a/progress2.inc
+++ b/progress2.inc
@@ -16,9 +16,9 @@
 #include <YSI_Coding\y_hooks>
 
 
-#define MAX_PLAYER_BARS (_:MAX_PLAYER_TEXT_DRAWS / 3)
-#define INVALID_PLAYER_BAR_VALUE (Float:0xFFFFFFFF)
-#define INVALID_PLAYER_BAR_ID (PlayerBar:-1)
+#define MAX_PLAYER_BARS					(_:MAX_PLAYER_TEXT_DRAWS / 3)
+#define INVALID_PLAYER_BAR_VALUE		(Float:0xFFFFFFFF)
+#define INVALID_PLAYER_BAR_ID			(PlayerBar:-1)
 
 enum {
 	BAR_DIRECTION_RIGHT,

--- a/progress2.inc
+++ b/progress2.inc
@@ -308,13 +308,6 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 		return 0;
 	}
 
-	if( value < 0.0 ) {
-		value = 0.0;
-	} else {
-		if( value > pbar_Data[playerid][_:barid][pbar_maxValue] ) {
-			value = pbar_Data[playerid][_:barid][pbar_maxValue];
-		}
-	}
 	new
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],

--- a/progress2.inc
+++ b/progress2.inc
@@ -311,6 +311,8 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 	} else {
 		if( value > pbar_Data[playerid][_:barid][pbar_maxValue] ) {
 			value = pbar_Data[playerid][_:barid][pbar_maxValue];
+		}
+	}
 	new
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],

--- a/progress2.inc
+++ b/progress2.inc
@@ -119,8 +119,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 	return 1;
 }
 
-stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
-{
+stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid) {
 	return ( IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show] );
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
@@ -344,8 +343,7 @@ stock SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction) {
 	Internal
 */
 
-_progress2_renderBar(playerid, barid)
-{
+_progress2_renderBar(playerid, barid) {
 	if( !IsPlayerConnected(playerid) ) {
 		return false;
 	}
@@ -454,8 +452,9 @@ hook OnPlayerDisconnect(playerid, reason) {
 
 hook OnScriptExit() {
 	for(new i = 0; i < MAX_PLAYERS; i++) {
-		if( IsPlayerConnected(i) )
+		if( IsPlayerConnected(i) ) {
 			DestroyAllPlayerProgressBars(i);
+		}
 	}
 }
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -114,7 +114,7 @@ stock DestroyPlayerProgressBar(playerid, PlayerBar:barid) {
 
 stock bool:IsPlayerProgressBarVisible(playerid, PlayerBar:barid)
 {
-   return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
+	return (IsValidPlayerProgressBar(playerid, barid) && pbar_Data[playerid][_:barid][pbar_show]);
 }
 stock ShowPlayerProgressBar(playerid, PlayerBar:barid) {
 	if(!IsValidPlayerProgressBar(playerid, barid)) {

--- a/progress2.inc
+++ b/progress2.inc
@@ -52,7 +52,7 @@ new
 	#if(defined _INC_y_iterate)
 		Iterator:pbar_Index[MAX_PLAYERS]<MAX_PLAYER_BARS>,
 	#endif
-    pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA]
+	pbar_Data[MAX_PLAYERS][MAX_PLAYER_BARS][E_BAR_DATA]
 ;
 
 //	Returns free player progress bar.

--- a/progress2.inc
+++ b/progress2.inc
@@ -317,10 +317,8 @@ stock SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value) {
 	;
 	if( value < 0.0 ) {
 		value = 0.0;
-	} else {
-		if( value > max_value ) {
-			value = max_value;
-		}
+	} else if( value > max_value ) {
+		value = max_value;
 	}
 	if( direction == BAR_DIRECTION_RIGHT || direction == BAR_DIRECTION_LEFT ) {
 		boundry_size = pbar_Data[playerid][barid][pbar_width];

--- a/progress2.inc
+++ b/progress2.inc
@@ -73,6 +73,8 @@ forward PlayerBar:CreatePlayerProgressBar(
 	Float:max = 100.0,
 	direction = BAR_DIRECTION_RIGHT
 );
+forward Float:GetPlayerProgressBarValue(playerid, PlayerBar:barid);
+forward Float:_bar_percent(Float:x, Float:widthorheight, Float:max, Float:value, direction);
 
 stock PlayerBar:CreatePlayerProgressBar(
 	playerid,


### PR DESCRIPTION
Apply able after "Refactoring part 2"

Aligned columns of definitions with tabs - now looks like table.

Fixed issues with code style at allocation memory, multiple spaces as tabs, missed spaces.
[Fixed space series to tabulation.]
Rewritten definition of functions with many arguments to many lines by groups.
Normalized {}-braces use under K&R style as everywhere else in exist …