### PR TITLE
Fix compiler error when not using open.mp libs

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -13,7 +13,7 @@
 
 #if !defined _INC_open_mp
 	#include <a_samp>
-	PlayerTextDrawBoxColour(playerid, PlayerText:textid, boxColour) = PlayerTextDrawBoxColor;
+	native PlayerTextDrawBoxColour(playerid, PlayerText:textid, boxColour) = PlayerTextDrawBoxColor;
 #endif
 
 #tryinclude <logger>


### PR DESCRIPTION
We have to declare the native properly.