### PR TITLE
Define new native name only if it hasn't been before

### DIFF
--- a/progress2.inc
+++ b/progress2.inc
@@ -11,9 +11,9 @@
 
 #tryinclude <open.mp>
 
-#if !defined _INC_open_mp
+#if !defined PlayerTextDrawBoxColour
 	#include <a_samp>
-	native PlayerTextDrawBoxColour(playerid, PlayerText:textid, boxColour) = PlayerTextDrawBoxColor;
+	#define PlayerTextDrawBoxColour PlayerTextDrawBoxColor
 #endif
 
 #tryinclude <logger>


### PR DESCRIPTION
To avoid possible errors about things being declared twice.  Before the library was only checking if `_INC_open_mp` is defined but if 2 different libraries were using the same method of patching, we would end up with 2 duplicated defines. Thus compilation errors.