### PR TITLE
Add padding, min value, new direction types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Include in your code and begin using the library:
   * Bar direction bottom to top
 * `BAR_DIRECTION_DOWN`:
   * Bar direction top to bottom
+* `BAR_DIRECTION_HORIZONTAL_FROM_0`
+  * Bar direction left to right and starts from 0.0 in case min_value and max_value have different signs.
+* `BAR_DIRECTION_VERTICAL_FROM_0`
+  * Bar direction down to up and starts from 0.0 in case min_value and max_value have different signs.
 
 ### Functions
 
@@ -71,6 +75,10 @@ Include in your code and begin using the library:
   * Returns the colour of a progress bar.
 * `SetPlayerProgressBarColour(playerid, PlayerBar:barid, colour)`:
   * Sets the colour of a progress bar.
+* `Float:GetPlayerProgressBarMinValue(playerid, PlayerBar:barid)`
+  * Returns the minumum value of a progress bar.
+* `SetPlayerProgressBarMinValue(playerid, PlayerBar:barid, Float:min_value)`
+  * Sets the minumum value that a progress bar represents.
 * `Float:GetPlayerProgressBarMaxValue(playerid, PlayerBar:barid)`:
   * Returns the maximum value of a progress bar.
 * `SetPlayerProgressBarMaxValue(playerid, PlayerBar:barid, Float:max)`:
@@ -79,10 +87,14 @@ Include in your code and begin using the library:
   * Returns the value a progress bar represents.
 * `SetPlayerProgressBarValue(playerid, PlayerBar:barid, Float:value)`:
   * Sets the value a progress bar represents.
-* `GetPlayerProgressBarDirection(playerid, PlayerBar:barid)`:
+* `progressbar_direction:GetPlayerProgressBarDirection(playerid, PlayerBar:barid)`:
   * Returns the direction of a progress bar.
-* `SetPlayerProgressBarDirection(playerid, PlayerBar:barid, direction)`:
+* `SetPlayerProgressBarDirection(playerid, PlayerBar:barid, progressbar_direction:direction)`:
   * Updates the direction for a progress bar and re-renders it.
+* `GetPlayerProgressBarPadding(playerid, PlayerBar:barid, &Float:padding_x, &Float:padding_y)`
+  * Receives current padding for both dimensions.
+* `SetPlayerProgressBarPadding(playerid, PlayerBar:barid, Float:padding_x, Float:padding_y)`
+  * Updates current padding for both dimensions.
 
 ### Internal
 

--- a/progress2.inc
+++ b/progress2.inc
@@ -31,14 +31,14 @@
 #define INVALID_PLAYER_BAR_VALUE		(Float:0xFFFFFFFF)
 #define INVALID_PLAYER_BAR_ID			(PlayerBar:-1)
 
-enum {
+enum progressbar_direction {
 	BAR_DIRECTION_RIGHT,
 	BAR_DIRECTION_LEFT,
 	BAR_DIRECTION_HORIZONTAL_FROM_0,
 	BAR_DIRECTION_UP,
 	BAR_DIRECTION_DOWN,
 	BAR_DIRECTION_VERTICAL_FROM_0,
-}
+};
 
 enum E_BAR_DATA {
 	bool:is_created,
@@ -53,7 +53,7 @@ enum E_BAR_DATA {
 	Float:pbar_progressValue,
 	Float:E_PADDING_X,
 	Float:E_PADDING_Y,
-	pbar_direction
+	progressbar_direction:pbar_direction
 }
 
 static const Float:direction_size_mult[] = {
@@ -116,7 +116,7 @@ forward PlayerBar:CreatePlayerProgressBar(
 	const Float:width = 55.5, const Float:height = 3.2,
 	const colour = 0xFF1C1CFF,
 	const Float:max = 100.0,
-	const direction = BAR_DIRECTION_RIGHT
+	const progressbar_direction:direction = BAR_DIRECTION_RIGHT
 );
 forward Float:GetPlayerProgressBarValue(const playerid, const PlayerBar:barid);
 
@@ -126,7 +126,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	const Float:width = 55.5, const Float:height = 3.2,
 	const colour = 0xFF1C1CFF,
 	const Float:max = 100.0,
-	const direction = BAR_DIRECTION_RIGHT
+	const progressbar_direction:direction = BAR_DIRECTION_RIGHT
 ) {
 	if( !IsPlayerConnected(playerid) ) {
 		#if(defined _logger_included)
@@ -374,7 +374,7 @@ stock SetPlayerProgressBarValue(const playerid, const PlayerBar:barid, Float:val
 	new
 		Float:min_value = pbar_Data[playerid][barid][pbar_minValue],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
-		direction = pbar_Data[playerid][barid][pbar_direction],
+		progressbar_direction:direction = pbar_Data[playerid][barid][pbar_direction],
 		Float:ratio_to,
 		Float:boundry_size,
 		Float:adopted_size,
@@ -423,15 +423,15 @@ stock Float:GetPlayerProgressBarValue(const playerid, const PlayerBar:barid) {
 }
 
 // pbar_direction
-stock GetPlayerProgressBarDirection(const playerid, const PlayerBar:barid) {
+stock progressbar_direction:GetPlayerProgressBarDirection(const playerid, const PlayerBar:barid) {
 	if( !IsValidPlayerProgressBar(playerid, barid) ) {
-		return 0;
+		return progressbar_direction:BAR_DIRECTION_RIGHT;
 	}
 
 	return pbar_Data[playerid][barid][pbar_direction];
 }
 
-stock SetPlayerProgressBarDirection(const playerid, const PlayerBar:barid, const direction) {
+stock SetPlayerProgressBarDirection(const playerid, const PlayerBar:barid, const progressbar_direction:direction) {
 	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return 0;
 	}
@@ -484,7 +484,7 @@ _progress2_renderBar(const playerid, const PlayerBar:barid) {
 		Float:min_value = pbar_Data[playerid][barid][pbar_minValue],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		Float:cur_value = pbar_Data[playerid][barid][pbar_progressValue],
-		direction = pbar_Data[playerid][barid][pbar_direction],
+		progressbar_direction:direction = pbar_Data[playerid][barid][pbar_direction],
 		color = pbar_Data[playerid][barid][pbar_colour],
 		Float:outer_pos_x2, Float:outer_pos_y2,	// 'back' pos (right bottom corner)
 		Float:inner_pos_x1, Float:inner_pos_y1,	// 'fill' pos (left upper corner)
@@ -616,7 +616,7 @@ stock DestroyAllPlayerProgressBars(const playerid) {
 	return 1;
 }
 
-static stock bar_getRatios(const direction, const Float:cur_value, const Float:min_value, const Float:max_value, &Float:ratio_from, &Float:ratio_to) {
+static stock bar_getRatios(const progressbar_direction:direction, const Float:cur_value, const Float:min_value, const Float:max_value, &Float:ratio_from, &Float:ratio_to) {
 	new Float:range_value = max_value - min_value;
 	if( direction == BAR_DIRECTION_HORIZONTAL_FROM_0 || direction == BAR_DIRECTION_VERTICAL_FROM_0 ) {	// From 0.
 		if( max_value < 0.0 ) {

--- a/progress2.inc
+++ b/progress2.inc
@@ -43,6 +43,8 @@ enum E_BAR_DATA {
 	pbar_colour,
 	Float:pbar_maxValue,
 	Float:pbar_progressValue,
+	Float:E_PADDING_X,
+	Float:E_PADDING_Y,
 	pbar_direction
 }
 
@@ -150,6 +152,8 @@ stock PlayerBar:CreatePlayerProgressBar(
 	pbar_Data[playerid][barid][pbar_maxValue] = max;
 	pbar_Data[playerid][barid][pbar_progressValue] = 0.0;
 	pbar_Data[playerid][barid][pbar_direction] = direction;
+	pbar_Data[playerid][barid][E_PADDING_X] = 1.2;
+	pbar_Data[playerid][barid][E_PADDING_Y] = 1.0;
 
 	#if(defined _INC_y_iterate)
 	Iter_Add(pbar_Index[playerid], barid);
@@ -409,6 +413,24 @@ stock SetPlayerProgressBarDirection(const playerid, const PlayerBar:barid, const
 	return 1;
 }
 
+stock GetPlayerProgressBarPadding(const playerid, const PlayerBar:barid, &Float:padding_x, &Float:padding_y) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
+		return 0;
+	}
+	padding_x = pbar_Data[playerid][barid][E_PADDING_X];
+	padding_y = pbar_Data[playerid][barid][E_PADDING_Y];
+	return 1;
+}
+stock SetPlayerProgressBarPadding(const playerid, const PlayerBar:barid, const Float:padding_x, const Float:padding_y) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
+		return 0;
+	}
+	pbar_Data[playerid][barid][E_PADDING_X] = padding_x;
+	pbar_Data[playerid][barid][E_PADDING_Y] = padding_y;
+	_progress2_renderBar(playerid, barid);
+	return 1;
+}
+
 /*
 	Internal
 */
@@ -427,6 +449,7 @@ _progress2_renderBar(const playerid, const PlayerBar:barid) {
 	new
 		Float:pos_x,
 		Float:pos_y,
+		Float:padding_x, Float:padding_y,
 		Float:width = pbar_Data[playerid][barid][pbar_width],
 		Float:height = pbar_Data[playerid][barid][pbar_height],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
@@ -438,6 +461,7 @@ _progress2_renderBar(const playerid, const PlayerBar:barid) {
 		PlayerText:ptd_main
 	;
 	GetPlayerProgressBarPos(playerid, barid, pos_x, pos_y);
+	GetPlayerProgressBarPadding(playerid, barid, padding_x, padding_y);
 	ptd_back = CreatePlayerTextDraw(playerid, pos_x, pos_y, "_");
 	switch(direction) {
 		case BAR_DIRECTION_RIGHT: {

--- a/progress2.inc
+++ b/progress2.inc
@@ -41,6 +41,7 @@ enum E_BAR_DATA {
 	Float:pbar_width,
 	Float:pbar_height,
 	pbar_colour,
+	Float:pbar_minValue,
 	Float:pbar_maxValue,
 	Float:pbar_progressValue,
 	Float:E_PADDING_X,
@@ -149,6 +150,7 @@ stock PlayerBar:CreatePlayerProgressBar(
 	pbar_Data[playerid][barid][pbar_width] = width;
 	pbar_Data[playerid][barid][pbar_height] = height;
 	pbar_Data[playerid][barid][pbar_colour] = colour;
+	pbar_Data[playerid][barid][pbar_minValue] = 0.0;
 	pbar_Data[playerid][barid][pbar_maxValue] = max;
 	pbar_Data[playerid][barid][pbar_progressValue] = 0.0;
 	pbar_Data[playerid][barid][pbar_direction] = direction;
@@ -314,7 +316,21 @@ stock SetPlayerProgressBarColour(const playerid, const PlayerBar:barid, const co
 	return 1;
 }
 
-// pbar_maxValue
+stock Float:GetPlayerProgressBarMinValue(const playerid, const PlayerBar:barid) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
+		return INVALID_PLAYER_BAR_VALUE;
+	}
+	return pbar_Data[playerid][barid][pbar_minValue];
+}
+
+stock SetPlayerProgressBarMinValue(const playerid, const PlayerBar:barid, const Float:min_value) {
+	if( !IsValidPlayerProgressBar(playerid, barid) ) {
+		return 0;
+	}
+	pbar_Data[playerid][barid][pbar_minValue] = min_value;
+	SetPlayerProgressBarValue(playerid, barid, pbar_Data[playerid][barid][pbar_progressValue]);
+	return 1;
+}
 stock Float:GetPlayerProgressBarMaxValue(const playerid, const PlayerBar:barid) {
 	if( !IsValidPlayerProgressBar(playerid, barid) ) {
 		return INVALID_PLAYER_BAR_VALUE;
@@ -341,6 +357,7 @@ stock SetPlayerProgressBarValue(const playerid, const PlayerBar:barid, Float:val
 	}
 
 	new
+		Float:min_value = pbar_Data[playerid][barid][pbar_minValue],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],
 		Float:boundry_size,
@@ -452,6 +469,7 @@ _progress2_renderBar(const playerid, const PlayerBar:barid) {
 		Float:padding_x, Float:padding_y,
 		Float:width = pbar_Data[playerid][barid][pbar_width],
 		Float:height = pbar_Data[playerid][barid][pbar_height],
+		Float:min_value = pbar_Data[playerid][barid][pbar_minValue],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		Float:cur_value = pbar_Data[playerid][barid][pbar_progressValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],

--- a/progress2.inc
+++ b/progress2.inc
@@ -1,3 +1,8 @@
+/*
+	Note 1: Background & filter TextDraws have normalized corner positions.
+	Note 2: Bar TextDraw have corners that associated with min & max values (unnormalized).
+	Note 3: _bar_percent is now DEPRECATED - do not ever use it.
+*/
 // built-in include guard removal
 // just in case the user has a local dependency with the same file name
 #if defined _inc_progress2
@@ -29,8 +34,10 @@
 enum {
 	BAR_DIRECTION_RIGHT,
 	BAR_DIRECTION_LEFT,
+	BAR_DIRECTION_HORIZONTAL_FROM_0,
 	BAR_DIRECTION_UP,
-	BAR_DIRECTION_DOWN
+	BAR_DIRECTION_DOWN,
+	BAR_DIRECTION_VERTICAL_FROM_0,
 }
 
 enum E_BAR_DATA {
@@ -48,6 +55,15 @@ enum E_BAR_DATA {
 	Float:E_PADDING_Y,
 	pbar_direction
 }
+
+static const Float:direction_size_mult[] = {
+	1.0,	// BAR_DIRECTION_RIGHT
+	-1.0,	// BAR_DIRECTION_LEFT
+	1.0,	// BAR_DIRECTION_HORIZONTAL_FROM_0
+	-1.0,	// BAR_DIRECTION_UP
+	1.0,	// BAR_DIRECTION_DOWN
+	-1.0	// BAR_DIRECTION_VERTICAL_FROM_0
+};
 
 enum E_BAR_TEXT_DRAW {
 	PlayerText:pbar_back,
@@ -103,7 +119,6 @@ forward PlayerBar:CreatePlayerProgressBar(
 	const direction = BAR_DIRECTION_RIGHT
 );
 forward Float:GetPlayerProgressBarValue(const playerid, const PlayerBar:barid);
-forward Float:_bar_percent(const Float:x, const Float:widthorheight, const Float:max, const Float:value, const direction);
 
 stock PlayerBar:CreatePlayerProgressBar(
 	const playerid,
@@ -360,37 +375,34 @@ stock SetPlayerProgressBarValue(const playerid, const PlayerBar:barid, Float:val
 		Float:min_value = pbar_Data[playerid][barid][pbar_minValue],
 		Float:max_value = pbar_Data[playerid][barid][pbar_maxValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],
+		Float:ratio_to,
 		Float:boundry_size,
 		Float:adopted_size,
 		PlayerText:ptr_main = pbar_TextDraw[playerid][barid][pbar_main]
 	;
-	if( value < 0.0 ) {
-		value = 0.0;
+	if( value < min_value ) {
+		value = min_value;
 	} else if( value > max_value ) {
 		value = max_value;
 	}
+	ratio_to = (value - min_value) / (max_value - min_value);
+
 	if( direction == BAR_DIRECTION_RIGHT || direction == BAR_DIRECTION_LEFT ) {
 		boundry_size = pbar_Data[playerid][barid][pbar_width];
 	} else {
 		boundry_size = pbar_Data[playerid][barid][pbar_height];
 	}
-	adopted_size = _bar_percent(
-		pbar_Data[playerid][barid][pbar_posX],
-		boundry_size,
-		max_value,
-		value,
-		direction
-	);
+	adopted_size = boundry_size * ratio_to * direction_size_mult[direction];
 
-	PlayerTextDrawUseBox(playerid, ptr_main, value > 0.0);
+	PlayerTextDrawUseBox(playerid, ptr_main, value > min_value);
 
 	pbar_Data[playerid][barid][pbar_progressValue] = value;
 
 	switch(direction) {
-		case BAR_DIRECTION_RIGHT, BAR_DIRECTION_LEFT: {
+		case BAR_DIRECTION_RIGHT, BAR_DIRECTION_LEFT, BAR_DIRECTION_HORIZONTAL_FROM_0: {
 			PlayerTextDrawTextSize(playerid, ptr_main, adopted_size, 0.0);
 		}
-		case BAR_DIRECTION_UP, BAR_DIRECTION_DOWN: {
+		case BAR_DIRECTION_UP, BAR_DIRECTION_DOWN, BAR_DIRECTION_VERTICAL_FROM_0: {
 			PlayerTextDrawLetterSize(playerid, ptr_main, 1.0, adopted_size);
 		}
 	}
@@ -474,63 +486,92 @@ _progress2_renderBar(const playerid, const PlayerBar:barid) {
 		Float:cur_value = pbar_Data[playerid][barid][pbar_progressValue],
 		direction = pbar_Data[playerid][barid][pbar_direction],
 		color = pbar_Data[playerid][barid][pbar_colour],
+		Float:outer_pos_x2, Float:outer_pos_y2,	// 'back' pos (right bottom corner)
+		Float:inner_pos_x1, Float:inner_pos_y1,	// 'fill' pos (left upper corner)
+		Float:inner_pos_x2, Float:inner_pos_y2,	// 'fill' pos (right bottom corner)
+		Float:inner_size_x, Float:inner_size_y,	// 'fill' size
+		Float:value_pos_x1, Float:value_pos_y1,
+		Float:value_pos_x2, Float:value_pos_y2,
+		Float:value_size_y,
+		Float:size_multiplier = direction_size_mult[direction],
+		bool:is_vertical = (direction > BAR_DIRECTION_HORIZONTAL_FROM_0),
+		Float:ratio_from,
+		Float:ratio_to,
 		PlayerText:ptd_back,
 		PlayerText:ptd_fill,
 		PlayerText:ptd_main
 	;
 	GetPlayerProgressBarPos(playerid, barid, pos_x, pos_y);
 	GetPlayerProgressBarPadding(playerid, barid, padding_x, padding_y);
-	ptd_back = CreatePlayerTextDraw(playerid, pos_x, pos_y, "_");
+	//	Computing normalized sizes and corner positions in canvas pixels.
+	outer_pos_x2 = pos_x + width;
+	outer_pos_y2 = pos_y + height;
+	inner_pos_x1 = pos_x + padding_x;
+	inner_pos_x2 = outer_pos_x2 - padding_x;
+	inner_pos_y1 = pos_y + padding_y;
+	inner_pos_y2 = outer_pos_y2 - padding_y;
+	inner_size_x = inner_pos_x2 - inner_pos_x1;
+	inner_size_y = inner_pos_y2 - inner_pos_y1;
+	bar_getRatios(direction, cur_value, min_value, max_value, ratio_from, ratio_to);
+	ratio_from *= size_multiplier;
+	ratio_to *= size_multiplier;
+	if( is_vertical ) {
+		value_pos_x1 = inner_pos_x1;
+		value_pos_x2 = inner_pos_x2;
+	} else {	// is horizontal.
+		value_pos_y1 = inner_pos_y1;
+		value_pos_y2 = inner_pos_y2;
+	}
 	switch(direction) {
-		case BAR_DIRECTION_RIGHT: {
-			PlayerTextDrawTextSize		(playerid, ptd_back, pos_x + width - 4.0, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_back, 1.0, height / 10.0);
-
-			ptd_fill = CreatePlayerTextDraw(playerid, pos_x + 1.2, pos_y + 2.15, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_fill, pos_x + width - 5.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_fill, 1.0, height / 10.0 - 0.35);
-
-			ptd_main = CreatePlayerTextDraw(playerid, pos_x + 1.2, pos_y + 2.15, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_main, _bar_percent(pos_x, width, max_value, cur_value, direction), 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_main, 1.0, height / 10.0 - 0.35);
+		case BAR_DIRECTION_RIGHT:				{ value_pos_x1 = inner_pos_x1; }
+		case BAR_DIRECTION_LEFT:				{ value_pos_x1 = inner_pos_x2; }
+		case BAR_DIRECTION_HORIZONTAL_FROM_0:	{ value_pos_x1 = inner_pos_x1; }
+		case BAR_DIRECTION_UP:					{ value_pos_y1 = inner_pos_y2; }
+		case BAR_DIRECTION_DOWN:				{ value_pos_y1 = inner_pos_y1; }
+		case BAR_DIRECTION_VERTICAL_FROM_0:		{ value_pos_y1 = inner_pos_y2; }
+	}
+	if( is_vertical ) {
+		value_pos_y2 = value_pos_y1;
+		value_pos_y1 += inner_size_y * ratio_from;
+		value_pos_y2 += inner_size_y * ratio_to;
+	} else {
+		value_pos_x2 = value_pos_x1;
+		value_pos_x1 += inner_size_x * ratio_from;
+		value_pos_x2 += inner_size_x * ratio_to;
+	}
+	// normalising ranges.
+	{
+		new Float:temp_value;
+		if( value_pos_x1 > value_pos_x2 ) {
+			temp_value = value_pos_x2;
+			value_pos_x2 = value_pos_x1;
+			value_pos_x1 = temp_value;
 		}
-		case BAR_DIRECTION_LEFT: {
-			PlayerTextDrawTextSize		(playerid, ptd_back, pos_x - width - 4.0, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_back, 1.0, height / 10.0);
-
-			ptd_fill = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y + 2.15, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_fill, pos_x - width - 2.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_fill, 1.0, height / 10.0 - 0.35);
-
-			ptd_main = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y + 2.15, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_main, _bar_percent(pos_x, width, max_value, cur_value, direction), 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_main, 1.0, height / 10.0 - 0.35);
-		}
-		case BAR_DIRECTION_UP: {
-			PlayerTextDrawTextSize		(playerid, ptd_back, pos_x - width - 4.0, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_back, 1.0, -((height / 10.0) * 1.02) -0.35);
-
-			ptd_fill = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y - 1.0, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_fill, pos_x - width - 2.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_fill, 1.0, -(height / 10.0) * 1.02);
-
-			ptd_main = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y - 1.0, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_main, pos_x - width - 2.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_main, 1.0, _bar_percent(pos_x, height, max_value, cur_value, direction));
-		}
-		case BAR_DIRECTION_DOWN: {
-			PlayerTextDrawTextSize		(playerid, ptd_back, pos_x - width - 4.0, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_back, 1.0, ((height / 10.0)) - 0.35);
-
-			ptd_fill = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y + 1.0, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_fill, pos_x - width - 2.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_fill, 1.0, (height / 10.0) - 0.55);
-
-			ptd_main = CreatePlayerTextDraw(playerid, pos_x - 1.2, pos_y + 1.0, "_");
-			PlayerTextDrawTextSize		(playerid, ptd_main, pos_x - width - 2.5, 0.0);
-			PlayerTextDrawLetterSize	(playerid, ptd_main, 1.0, _bar_percent(pos_x, height, max_value, cur_value, direction));
+		if( value_pos_y1 > value_pos_y2 ) {
+			temp_value = value_pos_y2;
+			value_pos_y2 = value_pos_y1;
+			value_pos_y1 = temp_value;
 		}
 	}
+	new Float:correction_x = 1.25;
+	value_pos_x1 += correction_x;
+	value_pos_x2 -= correction_x;
+	inner_pos_x1 += correction_x;
+	inner_pos_x2 -= correction_x;
+
+	value_size_y = value_pos_y2 - value_pos_y1;
+
+	ptd_back = CreatePlayerTextDraw(playerid, pos_x, pos_y, "_");
+	ptd_fill = CreatePlayerTextDraw(playerid, inner_pos_x1, inner_pos_y1, "_");
+	ptd_main = CreatePlayerTextDraw(playerid, value_pos_x1, value_pos_y1, "_");
+	PlayerTextDrawTextSize(playerid, ptd_main, value_pos_x2, 0.0);
+	PlayerTextDrawLetterSize(playerid, ptd_main, 1.0, value_size_y / 10.0);
+
+	PlayerTextDrawTextSize		(playerid, ptd_back, outer_pos_x2, 0.0);
+	PlayerTextDrawLetterSize	(playerid, ptd_back, 1.0, height / 10.0);
+	PlayerTextDrawTextSize		(playerid, ptd_fill, inner_pos_x2, 0.0);
+	PlayerTextDrawLetterSize	(playerid, ptd_fill, 1.0, inner_size_y / 10.0);
+
 	pbar_TextDraw[playerid][barid][pbar_back] = ptd_back;
 	pbar_TextDraw[playerid][barid][pbar_fill] = ptd_fill;
 	pbar_TextDraw[playerid][barid][pbar_main] = ptd_main;
@@ -575,23 +616,18 @@ stock DestroyAllPlayerProgressBars(const playerid) {
 	return 1;
 }
 
-stock Float:_bar_percent(const Float:x, const Float:widthorheight, const Float:max, const Float:value, const direction) {
-	new Float:result;
-
-	switch(direction) {
-		case BAR_DIRECTION_RIGHT: {
-			result = ((x - 3.0) + (((((x - 2.0) + widthorheight) - x) / max) * value));
+static stock bar_getRatios(const direction, const Float:cur_value, const Float:min_value, const Float:max_value, &Float:ratio_from, &Float:ratio_to) {
+	new Float:range_value = max_value - min_value;
+	if( direction == BAR_DIRECTION_HORIZONTAL_FROM_0 || direction == BAR_DIRECTION_VERTICAL_FROM_0 ) {	// From 0.
+		if( max_value < 0.0 ) {
+			ratio_from = 1.0;
+		} else if( min_value > 0.0 ) {
+			ratio_from = 0.0;
+		} else {
+			ratio_from = -min_value / range_value;
 		}
-		case BAR_DIRECTION_LEFT: {
-			result = ((x - 1.0) - (((((x + 2.0) - widthorheight) - x) / max) * -value)) - 4.0;
-		}
-		case BAR_DIRECTION_UP: {
-			result = -((((((widthorheight / 10.0) - 0.45) * 1.02) / max) * value) + 0.55);
-		}
-		case BAR_DIRECTION_DOWN: {
-			result = ((((((widthorheight / 10.0) - 0.45) * 1.02) / max) * value) - 0.55);
-		}
+	} else {
+		ratio_from = 0.0;
 	}
-
-	return result;
+	ratio_to = (cur_value - min_value) / range_value;
 }


### PR DESCRIPTION
Added new directions types: bar line starts where 0.0 value appears. Horizontal and vertical types.
It is now possible to set minimum value of progress bar (0 by default).
Bar direction types is now tagged because of new types (and their different sequence).
It is now possible to customize border width (called 'padding') for x- and y- dimensions. #25 
